### PR TITLE
Navigation interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Added interface for `blog-post-container` and `blog-post-navigation`
+
 ## [0.1.0] - 2020-04-28
 
 ### Added

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -18,10 +18,7 @@
   "blog-post-container": {
     "component": "Noop",
     "extensible": "public",
-    "composition": "children",
-    "allowed": [
-      "blog-post-navigation"
-    ]
+    "composition": "children"
   },
   "blog-post-details": {
     "component": "Noop",

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -20,7 +20,6 @@
     "extensible": "public",
     "composition": "children",
     "allowed": [
-      "blog-post-details",
       "blog-post-navigation"
     ]
   },

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -15,6 +15,15 @@
     "component": "Noop",
     "extensible": "public"
   },
+  "blog-post-container": {
+    "component": "Noop",
+    "extensible": "public",
+    "composition": "children",
+    "allowed": [
+      "blog-post-details",
+      "blog-post-navigation"
+    ]
+  },
   "blog-post-details": {
     "component": "Noop",
     "extensible": "public",
@@ -22,6 +31,10 @@
     "allowed": [
       "blog-related-products"
     ]
+  },
+  "blog-post-navigation": {
+    "component": "Noop",
+    "extensible": "public"
   },
   "blog-page-details": {
     "component": "Noop",


### PR DESCRIPTION
Adds interface for `blog-post-container` and `blog-post-navigation`, related to https://github.com/vtex-apps/wordpress-integration/pull/45.